### PR TITLE
feat: Support other builds of GnuPG such as MacGPG

### DIFF
--- a/gpg_key.py
+++ b/gpg_key.py
@@ -996,7 +996,7 @@ class GpgKey(object):
         lines = stdout.splitlines()
 
         # find gpg version
-        regex_gpg = r"gpg\s+\(GnuPG\)\s+(\d+\.\d+\.?\d*)$"
+        regex_gpg = r"gpg\s+\(GnuPG[^)]*\)\s+(\d+\.\d+\.?\d*)$"
         match_gpg = re.search(regex_gpg, lines[0])
 
         # sanity check


### PR DESCRIPTION
The current version check checks for the `gpg (GnuPG) x.x.x` format; this fails for MacGPG, which returns `gpg (GnuPG/MacGPG2) 2.2.24`.

My solution was to make the regex less strict and allow any extra sequence of characters before the closing `)`.