### PR TITLE
Enable importing secret keys

### DIFF
--- a/gpg_key.py
+++ b/gpg_key.py
@@ -932,6 +932,7 @@ class GpgKey(object):
         # file present
         if action == "file" and state == "present":
             args = [
+		  "--batch",
                 "--import",
                 self.module.params["file"],
             ]


### PR DESCRIPTION
Secret keys cannot be imported using this module because GPG prompts for a passphrase by default. This change applies the workaround from https://dev.gnupg.org/T2313 to import secret keys non-interactively using `--batch`.