### PR TITLE
Looks like, elder versions of GnuPG does not support show-only.

### DIFF
--- a/gpg_key.py
+++ b/gpg_key.py
@@ -923,8 +923,9 @@ class GpgKey(object):
         if action == "check" and state == "file":
             args = [
                 "--with-colons",
+                "--dry-run",
                 "--import-options",
-                "show-only",
+                "import-show",
                 "--import",
                 self.module.params["file"],
             ]


### PR DESCRIPTION
However, it seems that this option is a combination of import-show
and --dry-run