### PR TITLE
Fix Syntax Warning

### DIFF
--- a/gpg_key.py
+++ b/gpg_key.py
@@ -768,7 +768,7 @@ class GpgKey(object):
 
             # see if any updates were downloaded or not
             # for some reason, gpg outputs these messages to stderr
-            updated = re.search('gpg:\s+unchanged: 1\n', stderr) is None
+            updated = re.search(r'gpg:\s+unchanged: 1\n', stderr) is None
             if updated:
                 updcnt += 1
 


### PR DESCRIPTION
Fix message with recent python version :
`<unknown>:771: SyntaxWarning: invalid escape sequence '\s'`